### PR TITLE
Исправил отображение ссылок

### DIFF
--- a/_pages/backup-nand.md
+++ b/_pages/backup-nand.md
@@ -56,8 +56,8 @@ author_profile: true
 1. Убедитесь, что включили [отображение расширений файлов](file-extensions-windows){:target="_blank"}, если у вас Windows
 1. Скопируйте **содержимое** папки `sample` из `.zip`-архива с [memloader](https://switchtools.sshnuke.net/){:target="_blank"} в **корень** вашей карты памяти
 1. Верните карту памяти обратно в Switch
-1. Скопируйте пейлоад `[memloader.bin](https://switchtools.sshnuke.net/){:target="_blank"}` в папку из которой передаёте их на Switch
-1. Запустите пейлоад `[memloader.bin](https://switchtools.sshnuke.net/){:target="_blank"}` с помощью [Fusée Gelée](fusee-gelee){:target="_blank"}
+1. Скопируйте пейлоад [`memloader.bin`](https://switchtools.sshnuke.net/){:target="_blank"} в папку из которой передаёте их на Switch
+1. Запустите пейлоад [`memloader.bin`](https://switchtools.sshnuke.net/){:target="_blank"} с помощью [Fusée Gelée](fusee-gelee){:target="_blank"}
 1. На экране приставки выберите `ums_eMMC.ini` и запустите
 	* Для перемещения по меню используйте клавиши (VOL-) и (VOL+), для выбора - (POWER)
 	* Обратите внимание, что выбрали именно "ums_**eMMC**.ini"
@@ -92,7 +92,7 @@ author_profile: true
 1. Вставьте карту памяти приставки в macOS
 1. Скопируйте **содержимое** папки `sample` из `.zip`-архива с [memloader](https://switchtools.sshnuke.net/){:target="_blank"} в **корень** вашей карты памяти
 1. Верните карту памяти обратно в Switch
-1. Запустите пейлоад `[memloader.bin](https://switchtools.sshnuke.net/){:target="_blank"}` с помощью [Fusée Gelée](fusee-gelee){:target="_blank"}
+1. Запустите пейлоад [`memloader.bin`](https://switchtools.sshnuke.net/){:target="_blank"} с помощью [Fusée Gelée](fusee-gelee){:target="_blank"}
 1. На экране приставки выберите `ums_eMMC.ini` и запустите
 	* Для перемещения по меню используйте клавиши (VOL-) и (VOL+), для выбора - (POWER)
 	* Обратите внимание, что выбрали именно "ums_**eMMC**.ini"


### PR DESCRIPTION
Ссылки обёрнутые в косые кавычки не отображаются внутри markdown и не рентерятся как внутри Jekyll, соотвественно.