### PR TITLE
security: update exosphere.ini for ban protection

### DIFF
--- a/kefir/exosphere.ini
+++ b/kefir/exosphere.ini
@@ -47,5 +47,13 @@
 #  Desc: Controls whether the logging uart port is inverted.
 
 [exosphere]
-blank_prodinfo_sysmmc=1
+debugmode=1
+debugmode_user=0
+disable_user_exception_handlers=0
+enable_user_pmu_access=0
+blank_prodinfo_sysmmc=0
 blank_prodinfo_emummc=1
+allow_writing_to_cal_sysmmc=0
+log_port=0
+log_baud_rate=115200
+log_inverted=0


### PR DESCRIPTION
This update is necessary to protect the console against bans by hiding the serial number in the emulated environment and securing the sysNAND calibration partition against accidental writes.

**Changes made:**
* Updated the existing `exosphere.ini` parameters.
* Enabled `blank_prodinfo_emummc=1` and kept `blank_prodinfo_sysmmc=0`.
* Blocked write access to the real memory via `allow_writing_to_cal_sysmmc=0`.
* Set standard default parameters for debug and logging.